### PR TITLE
Add "headless" support

### DIFF
--- a/env
+++ b/env
@@ -37,3 +37,11 @@ export HOOK_SNAPSHOT_ID_FILE="snapshot-id.txt"
 
 # True to enable the 'pdb' command; False otherwise. Non-bool values will raise an exception in the program.
 export HOOK_DEBUG=bool
+
+# True if this script will be run on a machine without a web browser such as a Raspberry Pi.
+# Note that you will still need to be able to access the console on the machine. The normal spotipy behavior for
+# OAuth token collection is to open a web browser to the SPOTIPY_REDIRECT_URI URL to ask for credentials, then to
+# collect the OAuth token from the redirected URL. The request URL can instead be printed to the console, allowing
+# you to copy it into a browser yourself to get the redirected URL. Paste that URL back into the console to allow
+# spotipy to access your music.
+export HOOK_HEADLESS=False

--- a/the_hook.py
+++ b/the_hook.py
@@ -32,7 +32,12 @@ bot = commands.Bot(intents=intents, command_prefix=bot_prefix)
 
 # FIXME: This needs to be tied to individual users eventually if this script is to become a real
 #        bot. It's global for now because only my account is used and the code is simpler this way.
-sp = spotipy.Spotify(auth_manager=SpotifyOAuth(scope=['playlist-read-private']))
+sp = spotipy.Spotify(
+    auth_manager=SpotifyOAuth(
+        scope=['playlist-read-private'],
+        open_browser=not config('HOOK_HEADLESS', default=False, cast=bool)
+    )
+)
 
 
 def get_playlist(pl_name: str) -> Playlist:


### PR DESCRIPTION
At least enough to get this script working on an old Raspberry Pi. Set the `HOOK_HEADLESS` variable to `True` to tell spotipy to print the authorization URL to the console instead of trying to open a browser to it on its own. Not fully "headless" since you still need console access to copy and paste the request and redirect URLs respectively, but it does work instead of getting stuck in lynx/www-browser muck. 